### PR TITLE
Add argparse CLI for OCR script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# ORC
+# OCR Payment Slip Processor
+
+This repository contains a Python script for extracting information from
+payment slip images. It relies on OpenCV and Tesseract by default with an
+optional EasyOCR mode.
+
+## Usage
+
+Run the script with one or more image paths:
+
+```bash
+python traningOCR.py IMAGE1.jpg IMAGE2.png
+```
+
+Use EasyOCR instead of Tesseract by passing `--easyocr`:
+
+```bash
+python traningOCR.py IMAGE1.jpg --easyocr
+```
+
+The script will print the parsed data and save a JSON file for each image.

--- a/traningOCR.py
+++ b/traningOCR.py
@@ -6,6 +6,7 @@ from PIL import Image
 import json
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
+import argparse
 
 class PaymentSlipOCR:
     def __init__(self):
@@ -269,24 +270,31 @@ class PaymentSlipOCR:
 
 # Example usage
 def main():
+    """Command line interface for processing payment slips."""
+    parser = argparse.ArgumentParser(description="Process payment slip images")
+    parser.add_argument(
+        "image_paths",
+        nargs="+",
+        help="Paths to payment slip images to process"
+    )
+    parser.add_argument(
+        "--easyocr",
+        action="store_true",
+        help="Use EasyOCR instead of Tesseract"
+    )
+    args = parser.parse_args()
+
     # Initialize OCR processor
     ocr_processor = PaymentSlipOCR()
-    
-    # Example usage with different image paths
-    image_paths = [
-        "payment_slip.jpg",
-        "receipt.png",
-        "invoice.pdf"  # Note: PDF would need conversion to image first
-    ]
-    
-    for image_path in image_paths:
+
+    for image_path in args.image_paths:
         try:
             print(f"\n{'='*50}")
             print(f"Processing: {image_path}")
             print(f"{'='*50}")
-            
+
             # Process the slip
-            results = ocr_processor.process_slip(image_path)
+            results = ocr_processor.process_slip(image_path, use_easyocr=args.easyocr)
             
             if "error" in results:
                 print(f"Error: {results['error']}")


### PR DESCRIPTION
## Summary
- use `argparse` to accept image paths and optional `--easyocr` flag
- remove hardcoded list of image files
- document command line usage in README

## Testing
- `python traningOCR.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6870603442248326a0af6c6328ee6b6c