### PR TITLE
Add detection/recognition losses

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Annotations are expected in a JSON file with the following structure:
 ]
 ```
 
+Each object in `boxes` must include the bounding box coordinates under the `bbox`
+key and the ground truth text string under `text`. The first character of this
+string is used for the recognition loss during training. A `language` field is
+optional.
+
 Images should cover a wide variety of scenes such as documents, signs and
 packaging captured in different lighting conditions, angles and resolutions.
 
@@ -53,6 +58,10 @@ python -m ocr.train --data-root /path/to/images --annotations annotations.json
 ```
 
 The model weights will be stored in `models/ocr_model.pt`.
+
+During training, bounding box regression and classification losses from the
+detector are combined with a character classification loss for the recognition
+branch. All losses are accumulated and backpropagated each iteration.
 
 ### Evaluation
 

--- a/ocr/model.py
+++ b/ocr/model.py
@@ -1,8 +1,9 @@
-from typing import List, Dict
-from PIL import Image
+from typing import List
 import torch
 from torch import nn
 from torchvision.models.detection import fasterrcnn_resnet50_fpn
+from torchvision.ops import roi_align
+import torchvision.transforms.functional as TF
 
 class DetectionModel(nn.Module):
     """Simple wrapper around Faster R-CNN for text detection."""
@@ -15,21 +16,30 @@ class DetectionModel(nn.Module):
     def forward(self, images: List[torch.Tensor], targets=None):
         return self.model(images, targets)
 
+VOCAB = "#0123456789abcdefghijklmnopqrstuvwxyz"
+
+# Map characters to indices for recognition training
+CHAR_TO_IDX = {c: i for i, c in enumerate(VOCAB)}
+
+
 class RecognitionModel(nn.Module):
-    """Placeholder for text recognition (e.g., CRNN)."""
-    def __init__(self):
+    """Simple classifier for single-character recognition."""
+
+    def __init__(self, num_classes: int = len(VOCAB)):
         super().__init__()
         self.conv = nn.Sequential(
             nn.Conv2d(3, 32, 3, padding=1),
             nn.ReLU(),
             nn.AdaptiveAvgPool2d((1, 1)),
         )
-        self.fc = nn.Linear(32, 128)
+        self.fc1 = nn.Linear(32, 128)
+        self.fc2 = nn.Linear(128, num_classes)
 
     def forward(self, images: torch.Tensor) -> torch.Tensor:
         features = self.conv(images)
         features = features.view(features.size(0), -1)
-        return self.fc(features)
+        features = torch.relu(self.fc1(features))
+        return self.fc2(features)
 
 class OCRModel(nn.Module):
     """Combined detection and recognition model."""
@@ -42,3 +52,22 @@ class OCRModel(nn.Module):
         detections = self.detector(images)
         # recognition step would require cropping detections and processing
         return detections
+
+
+def recognition_targets_from_annotations(images: List[torch.Tensor], annotations: List[List[dict]], size: int = 32):
+    """Generate cropped regions and target indices from annotations."""
+    crops = []
+    labels = []
+    for img, ann in zip(images, annotations):
+        for box in ann:
+            x1, y1, x2, y2 = map(int, box["bbox"])
+            if x2 <= x1 or y2 <= y1:
+                continue
+            crop = TF.resized_crop(img, y1, x1, y2 - y1, x2 - x1, (size, size))
+            crops.append(crop)
+            text = box.get("text", "").lower()
+            char = text[0] if text else "#"
+            labels.append(CHAR_TO_IDX.get(char, 0))
+    if not crops:
+        return None, None
+    return torch.stack(crops), torch.tensor(labels, dtype=torch.long)


### PR DESCRIPTION
## Summary
- implement single-character recognition model and helper utilities
- generate recognition training samples from annotations
- accumulate detection and recognition losses in training loop
- document annotation requirements and combined losses

## Testing
- `python -m py_compile ocr/*.py pipeline.py traningOCR.py`

------
https://chatgpt.com/codex/tasks/task_e_68713e522f1c832694ddd73967cb6327